### PR TITLE
Pass the event from onClick to _handleFigureClick to avoid calling preventDefault on undefined

### DIFF
--- a/src/Coverflow.js
+++ b/src/Coverflow.js
@@ -45,7 +45,7 @@ class Coverflow extends Component {
       height: this.props.height || 'auto',
     };
   }
-  
+
   static propTypes = {
     children: PropTypes.node.isRequired,
     displayQuantityOfSide: PropTypes.number.isRequired,
@@ -81,9 +81,9 @@ class Coverflow extends Component {
         this.refs[figureID].addEventListener(event, HandleAnimationState.bind(this));
       }
     });
-    
+
     const eventListener = window && window.addEventListener;
-    
+
     if(eventListener) {
       window.addEventListener('resize', this.updateDimensions.bind(this));
     }
@@ -109,7 +109,7 @@ class Coverflow extends Component {
 
     // if(removeListener) {
     //   window.removeEventListener('resize', this.updateDimensions.bind(this));
-    // } 
+    // }
   }
 
   updateDimensions(active) {
@@ -144,7 +144,7 @@ class Coverflow extends Component {
       <div
         className={styles.container}
         style={
-          Object.keys(media).length !== 0 ? media : 
+          Object.keys(media).length !== 0 ? media :
           { width: `${width}px`, height: `${height}px` }
         }
         onWheel={enableScroll ? this._handleWheel.bind(this) : null}
@@ -274,7 +274,7 @@ class Coverflow extends Component {
         <figure
           className={styles.figure}
           key={index}
-          onClick={() => this._handleFigureClick(index, figureElement.props['data-action']) }
+          onClick={(e) => this._handleFigureClick(index, figureElement.props['data-action'], e) }
           style={style}
           ref={`figure_${index}`}
         >

--- a/src/Coverflow.js
+++ b/src/Coverflow.js
@@ -45,7 +45,7 @@ class Coverflow extends Component {
       height: this.props.height || 'auto',
     };
   }
-
+  
   static propTypes = {
     children: PropTypes.node.isRequired,
     displayQuantityOfSide: PropTypes.number.isRequired,
@@ -81,9 +81,9 @@ class Coverflow extends Component {
         this.refs[figureID].addEventListener(event, HandleAnimationState.bind(this));
       }
     });
-
+    
     const eventListener = window && window.addEventListener;
-
+    
     if(eventListener) {
       window.addEventListener('resize', this.updateDimensions.bind(this));
     }
@@ -109,7 +109,7 @@ class Coverflow extends Component {
 
     // if(removeListener) {
     //   window.removeEventListener('resize', this.updateDimensions.bind(this));
-    // }
+    // } 
   }
 
   updateDimensions(active) {

--- a/src/Coverflow.js
+++ b/src/Coverflow.js
@@ -144,7 +144,7 @@ class Coverflow extends Component {
       <div
         className={styles.container}
         style={
-          Object.keys(media).length !== 0 ? media :
+          Object.keys(media).length !== 0 ? media : 
           { width: `${width}px`, height: `${height}px` }
         }
         onWheel={enableScroll ? this._handleWheel.bind(this) : null}


### PR DESCRIPTION
This PR fixes a runtime error that occurs upon clicking an item in the coverflow collection:

```
Uncaught TypeError: Cannot read property 'preventDefault' of undefined
    at ProxyComponent.Coverflow._this._handleFigureClick (Coverflow.js?b672:257)
    at onClick (Coverflow.js?b672:277)
```